### PR TITLE
Split locations bug

### DIFF
--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -10,4 +10,21 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :nc_state, class: Spree::State do
+    name 'North Carolina'
+    abbr 'NC'
+    country do |country|
+      if usa = Spree::Country.find_by_numcode(840)
+        country = usa
+      else
+        country.association(:country)
+      end
+    end
+
+    factory :nv_state do
+      name 'Nevada'
+      abbr 'NV'
+    end
+  end
 end

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -24,5 +24,20 @@ FactoryGirl.define do
         stock_location.stock_items.where(variant_id: product_2.master.id).first.adjust_count_on_hand(20)
       end
     end
+
+    factory :east_coast_stock_location, parent: :stock_location do
+      name 'East Coast'
+      address1 'Some St'
+      city 'Durham'
+      state factory: :nc_state
+      zipcode '27703'
+    end
+
+    factory :west_coast_stock_location, parent: :stock_location do
+      name 'West Coast'
+      city 'RENO'
+      state factory: :nv_state
+      zipcode '89512'
+    end
   end
 end

--- a/frontend/spec/features/location_splitting_spec.rb
+++ b/frontend/spec/features/location_splitting_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+
+describe 'shipping', type: :feature, js: true do
+  let!(:user) { create(:user) }
+
+  let!(:east_coast_location) { create(:east_coast_stock_location, backorderable_default: true) }
+  let!(:west_coast_location) { create(:west_coast_stock_location) }
+
+  def fill_in_address(addr_type, address)
+    address_field = "#{addr_type}_attributes"
+    fill_in "#{address_field}_firstname", with: address.firstname
+    fill_in "#{address_field}_lastname",  with: address.lastname
+    fill_in "#{address_field}_address1",  with: address.address1
+    fill_in "#{address_field}_address2",  with: address.address2
+    fill_in "#{address_field}_city",      with: address.city
+    select "#{address.state.name}",       from: "#{address_field}_state_id"
+    fill_in "#{address_field}_zipcode",   with: address.zipcode
+    fill_in "#{address_field}_phone",     with: address.phone
+  end
+
+
+  describe 'deciding from which location to ship' do
+
+    include_context 'checkout setup'
+
+    before do
+      Spree::StockLocation.last.destroy # get rid of NY
+
+      visit spree.root_path
+      click_link mug.name
+      fill_in 'quantity', with: 2
+      click_button "add-to-cart-button"
+      @order = Spree::Order.last
+      @order.update_column(:email, "test@example.com")
+
+      puts Spree::StockLocation.all.to_a.map{|s| s.name}
+
+      @east_coast_address = create(:ship_address, zipcode: '27703', city: 'Durham', state: east_coast_location.state, country: east_coast_location.country)
+
+      @order.update_attributes(ship_address: @east_coast_address)
+      click_button 'Checkout'
+    end
+
+    it 'ensures that packages ship from both locations since there is one in each' do
+      Spree::StockItem.all.each{|si| si.set_count_on_hand(1); si.update_attributes!(backorderable: false)}
+
+      fill_in_address 'order_bill_address', @order.ship_address
+      check 'order_use_billing'
+      click_button 'Save and Continue'
+
+      page.should have_content 'East Coast'
+      page.should have_content 'West Coast'
+      page.should_not have_content 'Unshippable Items'
+    end
+    end
+end


### PR DESCRIPTION
Please keep this open. This test just reveals the problem. I am working on a fix. 

Essentially if I have two locations that can ship 1 item each and I request 2 items in the cart, I should get a split order with two shipments, 1 item coming from each stock location. 

What happens now is the default_package method of Spree::Packer only associates the first inventory_unit with both of the packages, never associating the second since only one item can be fulfilled. Later the Spree::Stock::Adjuster in the adjust method says the first stock location can ship the first inventory_unit and removes it from the other packages. 

I think a solution will center around not adding contents to the package until the adjust phase and instead in the default_package method adding an array of items that this package could possibly fulfill. 

I'll be working on this over the next day or so but any feedback would be appreciated.